### PR TITLE
fix: `Detail` 상세 이미지 숫자 표시 및 뒤로가기 버튼 문제 해결

### DIFF
--- a/src/components/CustomModal/CustomModal.tsx
+++ b/src/components/CustomModal/CustomModal.tsx
@@ -7,7 +7,6 @@ type CustomModalProps = Pick<
   ModalProps,
   | 'isVisible'
   | 'backdropOpacity'
-  | 'onBackdropPress'
   | 'onShow'
   | 'animationIn'
   | 'animationOut'
@@ -15,11 +14,12 @@ type CustomModalProps = Pick<
   | 'useNativeDriver'
 > & {
   children: React.ReactNode;
+  onModalClose: () => void;
 };
 
-const CustomModal = ({ children, ...props }: CustomModalProps) => {
+const CustomModal = ({ children, onModalClose, ...props }: CustomModalProps) => {
   return (
-    <Modal style={modalStyle} {...props}>
+    <Modal style={modalStyle} onBackdropPress={onModalClose} onBackButtonPress={onModalClose} {...props}>
       {children}
     </Modal>
   );

--- a/src/components/ImageGrid/ImageGrid.tsx
+++ b/src/components/ImageGrid/ImageGrid.tsx
@@ -75,7 +75,7 @@ const ImageGrid = ({ name, distance, tags, images }: Props) => {
       <CustomModal
         isVisible={visibleInput}
         backdropOpacity={1}
-        onBackdropPress={handleCloseButton}
+        onModalClose={handleCloseButton}
         animationIn="slideInUp"
         animationOut="slideOutDown"
         hideModalContentWhileAnimating={true}

--- a/src/components/ImageGrid/ImageGrid.tsx
+++ b/src/components/ImageGrid/ImageGrid.tsx
@@ -32,10 +32,11 @@ interface Props {
 }
 
 const ImageGrid = ({ name, distance, tags, images }: Props) => {
-  const [visibleInput, setVisibleInput] = useState<number>(-1);
+  const [visibleInput, setVisibleInput] = useState<boolean>(false);
+  const [imageIndex, setImageIndex] = useState<number>(0);
 
   const handleCloseButton = () => {
-    setVisibleInput(-1);
+    setVisibleInput(false);
   };
 
   const renderPagination = (index: number, total: number) => {
@@ -62,7 +63,8 @@ const ImageGrid = ({ name, distance, tags, images }: Props) => {
         <FBCollage
           images={images}
           imageOnPress={(index) => {
-            setVisibleInput(index);
+            setImageIndex(index);
+            setVisibleInput(true);
           }}
           width={Dimensions.get('window').width}
           height={150}
@@ -71,7 +73,7 @@ const ImageGrid = ({ name, distance, tags, images }: Props) => {
         />
       </ImageWrapper>
       <CustomModal
-        isVisible={visibleInput !== -1}
+        isVisible={visibleInput}
         backdropOpacity={1}
         onBackdropPress={handleCloseButton}
         animationIn="slideInUp"
@@ -83,7 +85,7 @@ const ImageGrid = ({ name, distance, tags, images }: Props) => {
           <CloseButton onPress={handleCloseButton}>
             <CloseWhiteIcon width="24" height="24" />
           </CloseButton>
-          <Swiper index={visibleInput} renderPagination={renderPagination}>
+          <Swiper index={imageIndex} renderPagination={renderPagination}>
             {images.map((image: string, index: number) => (
               <CardImage key={index}>
                 <AutoFitImage source={{ uri: image }} />

--- a/src/screens/Detail/Detail.tsx
+++ b/src/screens/Detail/Detail.tsx
@@ -299,7 +299,7 @@ const Detail = ({ navigation: { goBack }, route }: Props) => {
       <CustomModal
         isVisible={visibleInput === 'Tags'}
         backdropOpacity={1}
-        onBackdropPress={handleCloseButton}
+        onModalClose={handleCloseButton}
         animationIn="slideInUp"
         animationOut="slideOutDown"
         hideModalContentWhileAnimating={true}
@@ -332,7 +332,7 @@ const Detail = ({ navigation: { goBack }, route }: Props) => {
       <CustomModal
         isVisible={visibleInput === 'Comments'}
         backdropOpacity={0.3}
-        onBackdropPress={handleCloseButton}
+        onModalClose={handleCloseButton}
         onShow={() => inputRef.current?.focus()}
         animationIn="slideInUp"
         animationOut="slideOutDown"
@@ -344,7 +344,7 @@ const Detail = ({ navigation: { goBack }, route }: Props) => {
       <CustomModal
         isVisible={visibleInput === 'CommentOption'}
         backdropOpacity={0.3}
-        onBackdropPress={handleCloseButton}
+        onModalClose={handleCloseButton}
         animationIn="fadeIn"
         animationOut="fadeOut"
         hideModalContentWhileAnimating={true}

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -145,7 +145,7 @@ const Profile = ({ navigation: { navigate, goBack } }: Props) => {
       <CustomModal
         backdropOpacity={0.3}
         isVisible={visibleInputModal}
-        onBackdropPress={() => setVisibleInputModal(false)}
+        onModalClose={() => setVisibleInputModal(false)}
         onShow={() => inputRef.current?.focus()}
         animationIn="slideInUp"
         animationOut="slideOutDown"
@@ -162,7 +162,7 @@ const Profile = ({ navigation: { navigate, goBack } }: Props) => {
       <CustomModal
         isVisible={visibleTagsModal}
         backdropOpacity={0}
-        onBackdropPress={handleCloseButton}
+        onModalClose={handleCloseButton}
         animationIn="slideInUp"
         animationOut="slideOutDown"
         hideModalContentWhileAnimating={true}

--- a/src/screens/Signup/Signup.tsx
+++ b/src/screens/Signup/Signup.tsx
@@ -129,7 +129,7 @@ const Signup = ({ navigation, route }: Props) => {
         <CustomModal
           backdropOpacity={0.3}
           isVisible={visibleInput}
-          onBackdropPress={() => setVisibleInput(false)}
+          onModalClose={() => setVisibleInput(false)}
           onShow={() => inputRef.current?.focus()}
           animationIn="slideInUp"
           animationOut="slideOutDown"


### PR DESCRIPTION
## 수정 내용
- `Detail` 페이지 : 상세 이미지 팝업을 닫을 때 표시되는 `index` 초기화 과정이 UI에 노출되는 문제
    - 모달 표시 상태와 이미지 인덱스 상태를 분리하는 방법으로 해결
- `Modal` 컴포넌트 : 안드로이드에서 뒤로가기 버튼 클릭 시 동작하지 않는 문제
    - `Modal` 내부에서 `onCloseModal` 함수를 받아, `onBackdropPress` , `onBackButtonPress` 로 적용